### PR TITLE
Change service name to product tier name

### DIFF
--- a/src/components/DashboardLayout/ServicesDropdown.jsx
+++ b/src/components/DashboardLayout/ServicesDropdown.jsx
@@ -107,7 +107,7 @@ const ServicesDropdown = () => {
                   // color={styleConfig.nineDotMenuTextColor}
                   color="#6E717F"
                 >
-                  {service.serviceName}
+                  {service.productTierName}
                 </Text>
               </Stack>
             </MenuItem>


### PR DESCRIPTION
Previously the "Select Services" header used `serviceName`, which was equal to all offerings.