### PR TITLE
Updated customer-signin , update-password apis

### DIFF
--- a/src/features/ProfileSettings/components/PasswordForm.jsx
+++ b/src/features/ProfileSettings/components/PasswordForm.jsx
@@ -4,7 +4,6 @@ import { Text } from "src/components/Typography/Typography";
 import { useMutation } from "@tanstack/react-query";
 import { useFormik } from "formik";
 import * as Yup from "yup";
-import crypto from "crypto-js";
 import useSnackbar from "src/hooks/useSnackbar";
 import Form from "src/components/FormElements/Form/Form";
 import { PasswordInput } from "src/components/NonDashboardComponents/FormElements/FormElements";
@@ -23,7 +22,7 @@ function ChangePassword() {
     (values) => {
       const payload = {
         password: values.password,
-        currentPasswordHash: values.currentPasswordHash,
+        currentPassword: values.currentPassword,
       };
       return updatePassword(payload);
     },
@@ -47,26 +46,25 @@ function ChangePassword() {
 
   const formik = useFormik({
     initialValues: {
-      currentpassword: "",
-      currentPasswordHash: "",
+      currentPassword: "",
       password: "",
-      confirmpassword: "",
+      confirmPassword: "",
     },
     onSubmit: (values) => {
-      values.currentPasswordHash = crypto
-        .SHA256(values["currentpassword"])
-        .toString(crypto.enc.Hex);
-
-      createChangePasswordMutation.mutate(values);
+      const payload = {
+        currentPassword: values.currentPassword,
+        password: values.password,
+      };
+      createChangePasswordMutation.mutate(payload);
     },
     validateOnChange: false,
     //   validationSchema: createImageRegistryValidationSchema,
     validationSchema: Yup.object({
-      currentpassword: Yup.string().required("Password is required"),
+      currentPassword: Yup.string().required("Current Password is required"),
       password: Yup.string()
         .required("Password is required")
         .matches(passwordRegex, passwordText),
-      confirmpassword: Yup.string()
+      confirmPassword: Yup.string()
         .required("Password is required")
         .oneOf([Yup.ref("password"), null], "Passwords must match"),
     }),
@@ -88,18 +86,18 @@ function ChangePassword() {
         <Box display="flex" alignItems="center" mt="20px">
           <FieldLabel required>Current Password</FieldLabel>
           <PasswordInput
-            name="currentpassword"
+            name="currentPassword"
             required
-            id="currentpassword"
+            id="currentPassword"
             placeholder="Current Password*"
-            value={formik.values.currentpassword}
+            value={formik.values.currentPassword}
             onChange={formik.handleChange}
             onBlur={formik.handleBlur}
             sx={{ marginLeft: "150px", width: "600px" }}
             error={
-              formik.touched.currentpassword && formik.errors.currentpassword
+              formik.touched.currentPassword && formik.errors.currentPassword
             }
-            errorMsg={formik.errors.currentpassword}
+            errorMsg={formik.errors.currentPassword}
             fullWidth
             mt="12px"
           />
@@ -126,18 +124,18 @@ function ChangePassword() {
         <Box display="flex" alignItems="center">
           <FieldLabel required>Confirm New Password</FieldLabel>
           <PasswordInput
-            name="confirmpassword"
-            id="confirmpassword"
+            name="confirmPassword"
+            id="confirmPassword"
             required
             placeholder="Confirm New Password*"
-            value={formik.values.confirmpassword}
+            value={formik.values.confirmPassword}
             onChange={formik.handleChange}
             sx={{ marginLeft: "110px", width: "600px" }}
             onBlur={formik.handleBlur}
             error={
-              formik.touched.confirmpassword && formik.errors.confirmpassword
+              formik.touched.confirmPassword && formik.errors.confirmPassword
             }
-            errorMsg={formik.errors.confirmpassword}
+            errorMsg={formik.errors.confirmPassword}
             fullWidth
             mt="12px"
           />

--- a/src/features/Signin/SigninPage.jsx
+++ b/src/features/Signin/SigninPage.jsx
@@ -3,7 +3,6 @@ import { useRouter } from "next/router";
 import { useMutation } from "@tanstack/react-query";
 import { Stack, Typography } from "@mui/material";
 import { useFormik } from "formik";
-import crypto from "crypto-js";
 import axios from "src/axios";
 import Cookies from "js-cookie";
 import * as Yup from "yup";
@@ -21,7 +20,7 @@ const createSigninValidationSchema = Yup.object({
   email: Yup.string()
     .email("Invalid email address")
     .required("Email is required"),
-  hashedPassword: Yup.string().required("Password is required"),
+  password: Yup.string().required("Password is required"),
 });
 
 const SigninPage = (props) => {
@@ -59,22 +58,11 @@ const SigninPage = (props) => {
   const formik = useFormik({
     initialValues: {
       email: "",
-      hashedPassword: "",
+      password: "",
     },
     enableReinitialize: true,
     onSubmit: (values) => {
-      let data = {};
-
-      for (let key in values) {
-        if (values[key]) {
-          data[key] = values[key];
-          if (key === "hashedPassword") {
-            data.hashedPassword = crypto
-              .SHA256(values[key])
-              .toString(crypto.enc.Hex);
-          }
-        }
-      }
+      let data = { ...values };
       signInMutation.mutate(data);
     },
     validationSchema: createSigninValidationSchema,
@@ -110,14 +98,14 @@ const SigninPage = (props) => {
           <FieldContainer>
             <FieldLabel required>Password</FieldLabel>
             <PasswordField
-              name="hashedPassword"
-              id="hashedPassword"
+              name="password"
+              id="password"
               placeholder="Enter your password"
-              value={values.hashedPassword}
+              value={values.password}
               onChange={handleChange}
               onBlur={handleBlur}
-              error={touched.hashedPassword && errors.hashedPassword}
-              helperText={touched.hashedPassword && errors.hashedPassword}
+              error={touched.password && errors.password}
+              helperText={touched.password && errors.password}
             />
           </FieldContainer>
 

--- a/src/server/utils/fetchProviderAuthToken.js
+++ b/src/server/utils/fetchProviderAuthToken.js
@@ -2,15 +2,24 @@ const axios = require("../axios");
 const ProviderAuthError = require("./ProviderAuthError");
 
 function fetchProviderAuthToken() {
-  return axios
-    .post("/signin", {
-      email: `${process.env.PROVIDER_EMAIL}`,
-      hashedPassword: `${process.env.PROVIDER_HASHED_PASS}`,
-    })
-    .catch((error) => {
-      console.error(error)
-      throw new ProviderAuthError();
-    });
+  const signInPayload = {
+    email: process.env.PROVIDER_EMAIL,
+    password: "",
+  };
+
+  //Sign in using PROVIDER_PASSWORD. If not available, sign in using PROVIDER_HASHED_PASS
+  //PROVIDER_HASHED_PASS will be deprecated
+  if (process.env.PROVIDER_PASSWORD !== undefined) {
+    signInPayload["password"] = process.env.PROVIDER_PASSWORD;
+  } else if (process.env.PROVIDER_HASHED_PASS !== undefined) {
+    delete signInPayload.password;
+    signInPayload["hashedPassword"] = process.env.PROVIDER_HASHED_PASS;
+  }
+
+  return axios.post("/signin", signInPayload).catch(() => {
+    console.error("Provider sign in failure");
+    throw new ProviderAuthError();
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
1) Changed customer sign, update password api calls to send plain password in payload instead on hashed password 
2) Changed signin api to allow signin using password with backward support for hashed password 

System will use the PROVIDER_PASSWORD environment variable for provider sign in. If PROVIDER_PASSWORD is not present, PROVIDER_HASHED_PASS(if available) will be used for the sign in