### PR TITLE
Fix environment type badge not visible on some pages

### DIFF
--- a/pages/access/[serviceId]/[environmentId]/[resourceId]/[resourceInstanceId].js
+++ b/pages/access/[serviceId]/[environmentId]/[resourceId]/[resourceInstanceId].js
@@ -30,6 +30,12 @@ import SubscriptionNotFoundUI from "src/components/Access/SubscriptionNotFoundUI
 import { checkIfResouceIsBYOA } from "src/utils/access/byoaResource";
 import Link from "next/link";
 
+export const getServerSideProps = async () => {
+  return {
+    props: {},
+  };
+};
+
 function ResourceInstance() {
   const router = useRouter();
   const [currentTab, setCurrentTab] = useState("Resource Instance Details");

--- a/pages/access/[serviceId]/[environmentId]/access-control.js
+++ b/pages/access/[serviceId]/[environmentId]/access-control.js
@@ -56,6 +56,12 @@ import Head from "next/head";
 
 const pageTitle = "Access Control";
 
+export const getServerSideProps = async () => {
+  return {
+    props: {},
+  };
+};
+
 function AccessControl() {
   const router = useRouter();
   const { serviceId, environmentId, source, productTierId, subscriptionId } =

--- a/pages/access/[serviceId]/[environmentId]/dashboard.js
+++ b/pages/access/[serviceId]/[environmentId]/dashboard.js
@@ -27,6 +27,12 @@ import useServiceHealth from "src/hooks/query/useServiceHealth";
 
 const pageTitle = "Dashboard";
 
+export const getServerSideProps = async () => {
+  return {
+    props: {},
+  };
+};
+
 function Dashboard(props) {
   const router = useRouter();
   const { serviceId, environmentId, source, productTierId, subscriptionId } =

--- a/pages/access/[serviceId]/[environmentId]/events.js
+++ b/pages/access/[serviceId]/[environmentId]/events.js
@@ -29,6 +29,12 @@ import Head from "next/head";
 
 const pageTitle = "Events";
 
+export const getServerSideProps = async () => {
+  return {
+    props: {},
+  };
+};
+
 function Events() {
   const router = useRouter();
   const { serviceId, environmentId, source, productTierId, subscriptionId } =

--- a/pages/access/api-document.js
+++ b/pages/access/api-document.js
@@ -27,6 +27,12 @@ const SwaggerDocs = dynamic(
   }
 );
 
+export const getServerSideProps = async () => {
+  return {
+    props: { },
+  };
+};
+
 export default function ApiDocument(props) {
   const router = useRouter();
   const { serviceId, environmentId, source, productTierId, subscriptionId } =

--- a/pages/access/service/[serviceId].js
+++ b/pages/access/service/[serviceId].js
@@ -114,6 +114,12 @@ const instanceStatuses = {
   DELETING: "DELETING",
 };
 
+export const getServerSideProps = async () => {
+  return {
+    props: {},
+  };
+};
+
 function MarketplaceService() {
   const [selectionModel, setSelectionModel] = useState([]);
   const [viewResourceInfo, setViewResourceInfo] = useState({});


### PR DESCRIPTION
Added getServerSideProps to pages which require the environmentType variable. environmentType is currently made available on the client side using a context provider which gets the value from getInitialProps from _app.jsx page which runs only once on initial page load

For the initial page load, getInitialProps will run on the server only. getInitialProps will then also run on the client when navigating to a different route with the next/link component or by using next/router

If getInitialProps is used in a custom _app.js, and the page being navigated to is using getServerSideProps, then getInitialProps will also run on the server

[Reference](https://nextjs.org/docs/pages/api-reference/functions/get-initial-props)