### PR TITLE
Set sameSite to Lax on token cookie

### DIFF
--- a/pages/idp-auth.js
+++ b/pages/idp-auth.js
@@ -61,7 +61,7 @@ function IDPAuth() {
       const jwtToken = response.data.jwtToken;
       sessionStorage.removeItem("authState");
       if (jwtToken) {
-        Cookies.set("token", jwtToken, { sameSite: "Strict", secure: true });
+        Cookies.set("token", jwtToken, { sameSite: "Lax", secure: true });
         axios.defaults.headers["Authorization"] = "Bearer " + jwtToken;
         router.replace("/service-plans");
       }

--- a/src/features/Signin/SigninPage.jsx
+++ b/src/features/Signin/SigninPage.jsx
@@ -52,7 +52,7 @@ const SigninPage = (props) => {
 
   function handleSignInSuccess(jwtToken) {
     if (jwtToken) {
-      Cookies.set("token", jwtToken, { sameSite: "Strict", secure: true });
+      Cookies.set("token", jwtToken, { sameSite: "Lax", secure: true });
       axios.defaults.headers["Authorization"] = "Bearer " + jwtToken;
       router.push("/service-plans");
     }


### PR DESCRIPTION
Set the Same-Site cookie attribute to Lax to allow the token cookie to be sent to the page requests when redirected from an external website