### PR TITLE
Filter cloud provider account instances, fix instance selection issue

### DIFF
--- a/pages/access/service/[serviceId].js
+++ b/pages/access/service/[serviceId].js
@@ -1056,23 +1056,29 @@ function MarketplaceService() {
         const cloudProviderResourceInstance =
           cloudProviderResourceInstanceResponse.data;
 
-        //aws
-        if (cloudProviderResourceInstance?.result_params?.aws_account_id) {
-          const cloudProviderAccount = {
-            id: instanceId,
-            type: "aws",
-          };
-          cloudProviderResInstances.push(cloudProviderAccount);
+        if (
+          ["READY", "RUNNING"].includes(cloudProviderResourceInstance?.status)
+        ) {
+          //aws
+          if (cloudProviderResourceInstance?.result_params?.aws_account_id) {
+            const cloudProviderAccount = {
+              id: instanceId,
+              type: "aws",
+              label: `${instanceId} (Account ID - ${cloudProviderResourceInstance?.result_params?.aws_account_id})`,
+            };
+            cloudProviderResInstances.push(cloudProviderAccount);
+          }
+          //gcp
+          if (cloudProviderResourceInstance?.result_params?.gcp_project_id) {
+            const cloudProviderAccount = {
+              id: instanceId,
+              type: "gcp",
+              label: `${instanceId} (Project ID - ${cloudProviderResourceInstance?.result_params?.gcp_project_id})`,
+            };
+            cloudProviderResInstances.push(cloudProviderAccount);
+          }
+          //later azure
         }
-        //gcp
-        if (cloudProviderResourceInstance?.result_params?.gcp_project_id) {
-          const cloudProviderAccount = {
-            id: instanceId,
-            type: "gcp",
-          };
-          cloudProviderResInstances.push(cloudProviderAccount);
-        }
-        //later azure
       })
     );
     setCloudProviderAccounts(cloudProviderResInstances);

--- a/src/components/Forms/CreateResourceInstanceForm.jsx
+++ b/src/components/Forms/CreateResourceInstanceForm.jsx
@@ -546,7 +546,7 @@ function CreateResourceInstanceForm(props) {
                           key={cloudProviderAccount.id}
                           value={cloudProviderAccount.id}
                         >
-                          {cloudProviderAccount.id}
+                          {cloudProviderAccount.label}
                         </MenuItem>
                       ))}
                     </Select>

--- a/src/features/Marketplace/MarketplaceProductTier/hooks/useProductTierRedirect.js
+++ b/src/features/Marketplace/MarketplaceProductTier/hooks/useProductTierRedirect.js
@@ -30,7 +30,7 @@ const useProductTierRedirect = () => {
       router.isReady &&
       (!serviceId || !environmentId)
     ) {
-      if (serviceOfferingsData.length > 0) {
+      if (serviceOfferingsData?.length > 0) {
         let selectedServiceOffering;
 
         if (!serviceId) {

--- a/src/features/ResourceInstance/components/InstancesTableHeader.tsx
+++ b/src/features/ResourceInstance/components/InstancesTableHeader.tsx
@@ -100,7 +100,7 @@ const InstancesTableHeader: FC<InstancesTableHeaderProps> = ({
     }
 
     const cliManagedResource = CLI_MANAGED_RESOURCES.includes(
-      selectedInstance?.detailedNetworkTopology[selectedResourceId]
+      selectedInstance?.detailedNetworkTopology?.[selectedResourceId]
         ?.resourceType
     );
 


### PR DESCRIPTION
Fixes:
1) The cloud provider account instance selection issue
2) Filter cloud provider account instances to show only READY/RUNNING status instance on the Instance Creation form dropdown
3) Show AWS Account ID/ GCP Account ID with the cloud provider account instance ID in the dropdown menu item 